### PR TITLE
build: install Rust for CI builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,6 +35,12 @@ jobs:
           tinygo-version: '0.31.2'
       - name: TinyGo version check
         run: tinygo version
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: wasm32-unknown-unknown
+      - name: Rust version check
+        run: rustc --version
       - name: Install gonew
         run: go install golang.org/x/tools/cmd/gonew@latest
       - name: Install Mechanoid CLI


### PR DESCRIPTION
This PR installs Rust as part of the CI build for wasm32-unknown-unknown modules built by the `mecha build` command update in https://github.com/hybridgroup/mechanoid/pull/27