### PR TITLE
all: update to wazero upstream

### DIFF
--- a/blinky/go.mod
+++ b/blinky/go.mod
@@ -2,12 +2,10 @@ module github.com/hybridgroup/mechanoid-examples/blinky
 
 go 1.22.0
 
-replace github.com/tetratelabs/wazero => github.com/orsinium-forks/wazero v0.0.0-20240305131633-28fdf656fe85
-
 require github.com/hybridgroup/mechanoid v0.0.0-20240309111213-758ddcc58e7a
 
 require (
 	github.com/hybridgroup/wasman v0.0.0-20240304140329-ce1ea6b61834 // indirect
 	github.com/orsinium-labs/wypes v0.1.4 // indirect
-	github.com/tetratelabs/wazero v1.6.0 // indirect
+	github.com/tetratelabs/wazero v1.7.1-0.20240401054209-4d6585d7da56 // indirect
 )

--- a/blinky/go.sum
+++ b/blinky/go.sum
@@ -2,9 +2,9 @@ github.com/hybridgroup/mechanoid v0.0.0-20240309111213-758ddcc58e7a h1:7Hdaw1lCp
 github.com/hybridgroup/mechanoid v0.0.0-20240309111213-758ddcc58e7a/go.mod h1:goPLq6Qim+Hr7nGeDflbxPNqhErDAdhpUmFp44URbo8=
 github.com/hybridgroup/wasman v0.0.0-20240304140329-ce1ea6b61834 h1:pP916/7OLromi+7fHcbw5jIXOT/idiEBQ3ucbl8caz8=
 github.com/hybridgroup/wasman v0.0.0-20240304140329-ce1ea6b61834/go.mod h1:rLavUo4P0xVcDeDnViYEpPQPoACmp1py9UTLPY/R7Lg=
-github.com/orsinium-forks/wazero v0.0.0-20240305131633-28fdf656fe85 h1:SEURwzbGfMFBbwCpcaDkkbZu7jUoPWT6fbJ3Zh+Ssow=
-github.com/orsinium-forks/wazero v0.0.0-20240305131633-28fdf656fe85/go.mod h1:0U0G41+ochRKoPKCJlh0jMg1CHkyfK8kDqiirMmKY8A=
 github.com/orsinium-labs/tinytest v1.0.0 h1:YiGm/whlGm3mn/ynx9CCFuvEa3Q6yEGrzrKXEqJOkdc=
 github.com/orsinium-labs/tinytest v1.0.0/go.mod h1:GwcYBp0aKi6zujzBXFpCnqw6RSLSp9JSedDyu/V1DF4=
 github.com/orsinium-labs/wypes v0.1.4 h1:+7oih2IDlEpz7laiL3sQFlIU8vjd5j/SwcYlPdIPc0Q=
 github.com/orsinium-labs/wypes v0.1.4/go.mod h1:FSNWGo8I6/D5RYXMkCxyu71TXJAlwJGQUxgs4i6MAwo=
+github.com/tetratelabs/wazero v1.7.1-0.20240401054209-4d6585d7da56 h1:sB7EW6YA2z8k4or+w8Tm2eo1wD/f4uQ31AffFfgRhvo=
+github.com/tetratelabs/wazero v1.7.1-0.20240401054209-4d6585d7da56/go.mod h1:ytl6Zuh20R/eROuyDaGPkp82O9C/DJfXAwJfQ3X6/7Y=

--- a/buttons/go.mod
+++ b/buttons/go.mod
@@ -32,7 +32,7 @@ require (
 	github.com/srwiley/oksvg v0.0.0-20220731023508-a61f04f16b76 // indirect
 	github.com/srwiley/rasterx v0.0.0-20210519020934-456a8d69b780 // indirect
 	github.com/stretchr/testify v1.8.0 // indirect
-	github.com/tetratelabs/wazero v1.6.0 // indirect
+	github.com/tetratelabs/wazero v1.7.1-0.20240401054209-4d6585d7da56 // indirect
 	github.com/tevino/abool v1.2.0 // indirect
 	github.com/yuin/goldmark v1.4.13 // indirect
 	golang.org/x/image v0.3.0 // indirect
@@ -43,5 +43,3 @@ require (
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 	honnef.co/go/js/dom v0.0.0-20210725211120-f030747120f2 // indirect
 )
-
-replace github.com/tetratelabs/wazero => github.com/orsinium-forks/wazero v0.0.0-20240305131633-28fdf656fe85

--- a/buttons/go.sum
+++ b/buttons/go.sum
@@ -244,8 +244,6 @@ github.com/neelance/sourcemap v0.0.0-20200213170602-2833bce08e4c/go.mod h1:Qr6/a
 github.com/nfnt/resize v0.0.0-20180221191011-83c6a9932646/go.mod h1:jpp1/29i3P1S/RLdc7JQKbRpFeM1dOBd8T9ki5s+AY8=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e h1:fD57ERR4JtEqsWbfPhv4DMiApHyliiK5xCTNVSPiaAs=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
-github.com/orsinium-forks/wazero v0.0.0-20240305131633-28fdf656fe85 h1:SEURwzbGfMFBbwCpcaDkkbZu7jUoPWT6fbJ3Zh+Ssow=
-github.com/orsinium-forks/wazero v0.0.0-20240305131633-28fdf656fe85/go.mod h1:0U0G41+ochRKoPKCJlh0jMg1CHkyfK8kDqiirMmKY8A=
 github.com/orsinium-labs/tinytest v1.0.0 h1:YiGm/whlGm3mn/ynx9CCFuvEa3Q6yEGrzrKXEqJOkdc=
 github.com/orsinium-labs/tinytest v1.0.0/go.mod h1:GwcYBp0aKi6zujzBXFpCnqw6RSLSp9JSedDyu/V1DF4=
 github.com/orsinium-labs/wypes v0.1.4 h1:+7oih2IDlEpz7laiL3sQFlIU8vjd5j/SwcYlPdIPc0Q=
@@ -293,6 +291,8 @@ github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
 github.com/stretchr/testify v1.8.0 h1:pSgiaMZlXftHpm5L7V1+rVB+AZJydKsMxsQBIJw4PKk=
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
 github.com/subosito/gotenv v1.2.0/go.mod h1:N0PQaV/YGNqwC0u51sEeR/aUtSLEXKX9iv69rRypqCw=
+github.com/tetratelabs/wazero v1.7.1-0.20240401054209-4d6585d7da56 h1:sB7EW6YA2z8k4or+w8Tm2eo1wD/f4uQ31AffFfgRhvo=
+github.com/tetratelabs/wazero v1.7.1-0.20240401054209-4d6585d7da56/go.mod h1:ytl6Zuh20R/eROuyDaGPkp82O9C/DJfXAwJfQ3X6/7Y=
 github.com/tevino/abool v1.2.0 h1:heAkClL8H6w+mK5md9dzsuohKeXHUpY7Vw0ZCKW+huA=
 github.com/tevino/abool v1.2.0/go.mod h1:qc66Pna1RiIsPa7O4Egxxs9OqkuxDX55zznh9K07Tzg=
 github.com/urfave/cli/v2 v2.4.0/go.mod h1:NX9W0zmTvedE5oDoOMs2RTC8RvdK98NTYZE5LbaEYPg=

--- a/buttons/modules/buttons/go.mod
+++ b/buttons/modules/buttons/go.mod
@@ -3,5 +3,3 @@ module github.com/hybridgroup/mechanoid-examples/buttons/modules/buttons
 go 1.22.0
 
 require github.com/hybridgroup/mechanoid v0.0.0-20240309154056-a4644a70b098
-
-replace github.com/tetratelabs/wazero => github.com/orsinium-forks/wazero v0.0.0-20240305131633-28fdf656fe85

--- a/display/go.mod
+++ b/display/go.mod
@@ -2,8 +2,6 @@ module github.com/hybridgroup/mechanoid-examples/display
 
 go 1.22.0
 
-replace github.com/tetratelabs/wazero => github.com/orsinium-forks/wazero v0.0.0-20240305131633-28fdf656fe85
-
 require (
 	github.com/aykevl/board v0.0.0-20240106144210-80ca76f77def
 	github.com/aykevl/tinygl v0.0.0-20240131130748-3033a2fd9182
@@ -34,7 +32,7 @@ require (
 	github.com/srwiley/oksvg v0.0.0-20220731023508-a61f04f16b76 // indirect
 	github.com/srwiley/rasterx v0.0.0-20210519020934-456a8d69b780 // indirect
 	github.com/stretchr/testify v1.8.0 // indirect
-	github.com/tetratelabs/wazero v1.6.0 // indirect
+	github.com/tetratelabs/wazero v1.7.1-0.20240401054209-4d6585d7da56 // indirect
 	github.com/tevino/abool v1.2.0 // indirect
 	github.com/yuin/goldmark v1.4.13 // indirect
 	golang.org/x/image v0.3.0 // indirect

--- a/display/go.sum
+++ b/display/go.sum
@@ -244,8 +244,6 @@ github.com/neelance/sourcemap v0.0.0-20200213170602-2833bce08e4c/go.mod h1:Qr6/a
 github.com/nfnt/resize v0.0.0-20180221191011-83c6a9932646/go.mod h1:jpp1/29i3P1S/RLdc7JQKbRpFeM1dOBd8T9ki5s+AY8=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e h1:fD57ERR4JtEqsWbfPhv4DMiApHyliiK5xCTNVSPiaAs=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
-github.com/orsinium-forks/wazero v0.0.0-20240305131633-28fdf656fe85 h1:SEURwzbGfMFBbwCpcaDkkbZu7jUoPWT6fbJ3Zh+Ssow=
-github.com/orsinium-forks/wazero v0.0.0-20240305131633-28fdf656fe85/go.mod h1:0U0G41+ochRKoPKCJlh0jMg1CHkyfK8kDqiirMmKY8A=
 github.com/orsinium-labs/tinytest v1.0.0 h1:YiGm/whlGm3mn/ynx9CCFuvEa3Q6yEGrzrKXEqJOkdc=
 github.com/orsinium-labs/tinytest v1.0.0/go.mod h1:GwcYBp0aKi6zujzBXFpCnqw6RSLSp9JSedDyu/V1DF4=
 github.com/orsinium-labs/wypes v0.1.4 h1:+7oih2IDlEpz7laiL3sQFlIU8vjd5j/SwcYlPdIPc0Q=
@@ -293,6 +291,8 @@ github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
 github.com/stretchr/testify v1.8.0 h1:pSgiaMZlXftHpm5L7V1+rVB+AZJydKsMxsQBIJw4PKk=
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
 github.com/subosito/gotenv v1.2.0/go.mod h1:N0PQaV/YGNqwC0u51sEeR/aUtSLEXKX9iv69rRypqCw=
+github.com/tetratelabs/wazero v1.7.1-0.20240401054209-4d6585d7da56 h1:sB7EW6YA2z8k4or+w8Tm2eo1wD/f4uQ31AffFfgRhvo=
+github.com/tetratelabs/wazero v1.7.1-0.20240401054209-4d6585d7da56/go.mod h1:ytl6Zuh20R/eROuyDaGPkp82O9C/DJfXAwJfQ3X6/7Y=
 github.com/tevino/abool v1.2.0 h1:heAkClL8H6w+mK5md9dzsuohKeXHUpY7Vw0ZCKW+huA=
 github.com/tevino/abool v1.2.0/go.mod h1:qc66Pna1RiIsPa7O4Egxxs9OqkuxDX55zznh9K07Tzg=
 github.com/urfave/cli/v2 v2.4.0/go.mod h1:NX9W0zmTvedE5oDoOMs2RTC8RvdK98NTYZE5LbaEYPg=

--- a/externref/go.mod
+++ b/externref/go.mod
@@ -2,8 +2,6 @@ module github.com/hybridgroup/mechanoid-examples/externref
 
 go 1.22.0
 
-replace github.com/tetratelabs/wazero => github.com/orsinium-forks/wazero v0.0.0-20240305131633-28fdf656fe85
-
 require (
 	github.com/hybridgroup/mechanoid v0.0.0-20240309111213-758ddcc58e7a
 	github.com/orsinium-labs/wypes v0.1.4
@@ -11,5 +9,5 @@ require (
 
 require (
 	github.com/hybridgroup/wasman v0.0.0-20240304140329-ce1ea6b61834 // indirect
-	github.com/tetratelabs/wazero v1.6.0 // indirect
+	github.com/tetratelabs/wazero v1.7.1-0.20240401054209-4d6585d7da56 // indirect
 )

--- a/externref/go.sum
+++ b/externref/go.sum
@@ -2,9 +2,9 @@ github.com/hybridgroup/mechanoid v0.0.0-20240309111213-758ddcc58e7a h1:7Hdaw1lCp
 github.com/hybridgroup/mechanoid v0.0.0-20240309111213-758ddcc58e7a/go.mod h1:goPLq6Qim+Hr7nGeDflbxPNqhErDAdhpUmFp44URbo8=
 github.com/hybridgroup/wasman v0.0.0-20240304140329-ce1ea6b61834 h1:pP916/7OLromi+7fHcbw5jIXOT/idiEBQ3ucbl8caz8=
 github.com/hybridgroup/wasman v0.0.0-20240304140329-ce1ea6b61834/go.mod h1:rLavUo4P0xVcDeDnViYEpPQPoACmp1py9UTLPY/R7Lg=
-github.com/orsinium-forks/wazero v0.0.0-20240305131633-28fdf656fe85 h1:SEURwzbGfMFBbwCpcaDkkbZu7jUoPWT6fbJ3Zh+Ssow=
-github.com/orsinium-forks/wazero v0.0.0-20240305131633-28fdf656fe85/go.mod h1:0U0G41+ochRKoPKCJlh0jMg1CHkyfK8kDqiirMmKY8A=
 github.com/orsinium-labs/tinytest v1.0.0 h1:YiGm/whlGm3mn/ynx9CCFuvEa3Q6yEGrzrKXEqJOkdc=
 github.com/orsinium-labs/tinytest v1.0.0/go.mod h1:GwcYBp0aKi6zujzBXFpCnqw6RSLSp9JSedDyu/V1DF4=
 github.com/orsinium-labs/wypes v0.1.4 h1:+7oih2IDlEpz7laiL3sQFlIU8vjd5j/SwcYlPdIPc0Q=
 github.com/orsinium-labs/wypes v0.1.4/go.mod h1:FSNWGo8I6/D5RYXMkCxyu71TXJAlwJGQUxgs4i6MAwo=
+github.com/tetratelabs/wazero v1.7.1-0.20240401054209-4d6585d7da56 h1:sB7EW6YA2z8k4or+w8Tm2eo1wD/f4uQ31AffFfgRhvo=
+github.com/tetratelabs/wazero v1.7.1-0.20240401054209-4d6585d7da56/go.mod h1:ytl6Zuh20R/eROuyDaGPkp82O9C/DJfXAwJfQ3X6/7Y=

--- a/filestore/go.mod
+++ b/filestore/go.mod
@@ -2,8 +2,6 @@ module github.com/hybridgroup/mechanoid-examples/filestore
 
 go 1.22.0
 
-replace github.com/tetratelabs/wazero => github.com/orsinium-forks/wazero v0.0.0-20240217173836-b12c024bcbe4
-
 require (
 	github.com/hybridgroup/mechanoid v0.0.0-20240309111213-758ddcc58e7a
 	github.com/orsinium-labs/wypes v0.1.4
@@ -13,7 +11,7 @@ require (
 require (
 	github.com/creack/goselect v0.1.2 // indirect
 	github.com/hybridgroup/wasman v0.0.0-20240304140329-ce1ea6b61834 // indirect
-	github.com/tetratelabs/wazero v1.6.0 // indirect
+	github.com/tetratelabs/wazero v1.7.1-0.20240401054209-4d6585d7da56 // indirect
 	golang.org/x/sys v0.0.0-20220829200755-d48e67d00261 // indirect
 	tinygo.org/x/tinyfs v0.3.1-0.20231212053859-32ae3f6bbad9 // indirect
 )

--- a/filestore/go.sum
+++ b/filestore/go.sum
@@ -6,8 +6,6 @@ github.com/hybridgroup/mechanoid v0.0.0-20240309111213-758ddcc58e7a h1:7Hdaw1lCp
 github.com/hybridgroup/mechanoid v0.0.0-20240309111213-758ddcc58e7a/go.mod h1:goPLq6Qim+Hr7nGeDflbxPNqhErDAdhpUmFp44URbo8=
 github.com/hybridgroup/wasman v0.0.0-20240304140329-ce1ea6b61834 h1:pP916/7OLromi+7fHcbw5jIXOT/idiEBQ3ucbl8caz8=
 github.com/hybridgroup/wasman v0.0.0-20240304140329-ce1ea6b61834/go.mod h1:rLavUo4P0xVcDeDnViYEpPQPoACmp1py9UTLPY/R7Lg=
-github.com/orsinium-forks/wazero v0.0.0-20240217173836-b12c024bcbe4 h1:MUh9e2izck9aROiwDsDm24UU7kHieYM2911U1t+NASs=
-github.com/orsinium-forks/wazero v0.0.0-20240217173836-b12c024bcbe4/go.mod h1:0U0G41+ochRKoPKCJlh0jMg1CHkyfK8kDqiirMmKY8A=
 github.com/orsinium-labs/tinytest v1.0.0 h1:YiGm/whlGm3mn/ynx9CCFuvEa3Q6yEGrzrKXEqJOkdc=
 github.com/orsinium-labs/tinytest v1.0.0/go.mod h1:GwcYBp0aKi6zujzBXFpCnqw6RSLSp9JSedDyu/V1DF4=
 github.com/orsinium-labs/wypes v0.1.4 h1:+7oih2IDlEpz7laiL3sQFlIU8vjd5j/SwcYlPdIPc0Q=
@@ -16,6 +14,8 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+github.com/tetratelabs/wazero v1.7.1-0.20240401054209-4d6585d7da56 h1:sB7EW6YA2z8k4or+w8Tm2eo1wD/f4uQ31AffFfgRhvo=
+github.com/tetratelabs/wazero v1.7.1-0.20240401054209-4d6585d7da56/go.mod h1:ytl6Zuh20R/eROuyDaGPkp82O9C/DJfXAwJfQ3X6/7Y=
 go.bug.st/serial v1.6.2 h1:kn9LRX3sdm+WxWKufMlIRndwGfPWsH1/9lCWXQCasq8=
 go.bug.st/serial v1.6.2/go.mod h1:UABfsluHAiaNI+La2iESysd9Vetq7VRdpxvjx7CmmOE=
 golang.org/x/sys v0.0.0-20220829200755-d48e67d00261 h1:v6hYoSR9T5oet+pMXwUWkbiVqx/63mlHjefrHmxwfeY=

--- a/filestore/modules/hello/go.mod
+++ b/filestore/modules/hello/go.mod
@@ -2,6 +2,4 @@ module github.com/hybridgroup/mechanoid-examples/filestore/modules/hello
 
 go 1.22.0
 
-replace github.com/tetratelabs/wazero => github.com/orsinium-forks/wazero v0.0.0-20240305131633-28fdf656fe85
-
 require github.com/hybridgroup/mechanoid v0.0.0-20240309134627-91c5ca6eff25

--- a/simple/go.mod
+++ b/simple/go.mod
@@ -2,8 +2,6 @@ module github.com/hybridgroup/mechanoid-examples/simple
 
 go 1.22.0
 
-replace github.com/tetratelabs/wazero => github.com/orsinium-forks/wazero v0.0.0-20240217173836-b12c024bcbe4
-
 require (
 	github.com/hybridgroup/mechanoid v0.0.0-20240309111213-758ddcc58e7a
 	github.com/orsinium-labs/wypes v0.1.4
@@ -11,5 +9,5 @@ require (
 
 require (
 	github.com/hybridgroup/wasman v0.0.0-20240304140329-ce1ea6b61834 // indirect
-	github.com/tetratelabs/wazero v1.6.0 // indirect
+	github.com/tetratelabs/wazero v1.7.1-0.20240401054209-4d6585d7da56 // indirect
 )

--- a/simple/go.sum
+++ b/simple/go.sum
@@ -2,9 +2,9 @@ github.com/hybridgroup/mechanoid v0.0.0-20240309111213-758ddcc58e7a h1:7Hdaw1lCp
 github.com/hybridgroup/mechanoid v0.0.0-20240309111213-758ddcc58e7a/go.mod h1:goPLq6Qim+Hr7nGeDflbxPNqhErDAdhpUmFp44URbo8=
 github.com/hybridgroup/wasman v0.0.0-20240304140329-ce1ea6b61834 h1:pP916/7OLromi+7fHcbw5jIXOT/idiEBQ3ucbl8caz8=
 github.com/hybridgroup/wasman v0.0.0-20240304140329-ce1ea6b61834/go.mod h1:rLavUo4P0xVcDeDnViYEpPQPoACmp1py9UTLPY/R7Lg=
-github.com/orsinium-forks/wazero v0.0.0-20240217173836-b12c024bcbe4 h1:MUh9e2izck9aROiwDsDm24UU7kHieYM2911U1t+NASs=
-github.com/orsinium-forks/wazero v0.0.0-20240217173836-b12c024bcbe4/go.mod h1:0U0G41+ochRKoPKCJlh0jMg1CHkyfK8kDqiirMmKY8A=
 github.com/orsinium-labs/tinytest v1.0.0 h1:YiGm/whlGm3mn/ynx9CCFuvEa3Q6yEGrzrKXEqJOkdc=
 github.com/orsinium-labs/tinytest v1.0.0/go.mod h1:GwcYBp0aKi6zujzBXFpCnqw6RSLSp9JSedDyu/V1DF4=
 github.com/orsinium-labs/wypes v0.1.4 h1:+7oih2IDlEpz7laiL3sQFlIU8vjd5j/SwcYlPdIPc0Q=
 github.com/orsinium-labs/wypes v0.1.4/go.mod h1:FSNWGo8I6/D5RYXMkCxyu71TXJAlwJGQUxgs4i6MAwo=
+github.com/tetratelabs/wazero v1.7.1-0.20240401054209-4d6585d7da56 h1:sB7EW6YA2z8k4or+w8Tm2eo1wD/f4uQ31AffFfgRhvo=
+github.com/tetratelabs/wazero v1.7.1-0.20240401054209-4d6585d7da56/go.mod h1:ytl6Zuh20R/eROuyDaGPkp82O9C/DJfXAwJfQ3X6/7Y=

--- a/thumby/go.mod
+++ b/thumby/go.mod
@@ -2,8 +2,6 @@ module github.com/hybridgroup/mechanoid-examples/thumby
 
 go 1.22.0
 
-replace github.com/tetratelabs/wazero => github.com/orsinium-forks/wazero v0.0.0-20240305131633-28fdf656fe85
-
 require (
 	github.com/hybridgroup/mechanoid v0.0.0-20240309111213-758ddcc58e7a
 	github.com/orsinium-labs/wypes v0.1.4
@@ -14,5 +12,5 @@ require (
 require (
 	github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510 // indirect
 	github.com/hybridgroup/wasman v0.0.0-20240304140329-ce1ea6b61834 // indirect
-	github.com/tetratelabs/wazero v1.6.0 // indirect
+	github.com/tetratelabs/wazero v1.7.1-0.20240401054209-4d6585d7da56 // indirect
 )

--- a/thumby/go.sum
+++ b/thumby/go.sum
@@ -4,12 +4,12 @@ github.com/hybridgroup/mechanoid v0.0.0-20240309111213-758ddcc58e7a h1:7Hdaw1lCp
 github.com/hybridgroup/mechanoid v0.0.0-20240309111213-758ddcc58e7a/go.mod h1:goPLq6Qim+Hr7nGeDflbxPNqhErDAdhpUmFp44URbo8=
 github.com/hybridgroup/wasman v0.0.0-20240304140329-ce1ea6b61834 h1:pP916/7OLromi+7fHcbw5jIXOT/idiEBQ3ucbl8caz8=
 github.com/hybridgroup/wasman v0.0.0-20240304140329-ce1ea6b61834/go.mod h1:rLavUo4P0xVcDeDnViYEpPQPoACmp1py9UTLPY/R7Lg=
-github.com/orsinium-forks/wazero v0.0.0-20240305131633-28fdf656fe85 h1:SEURwzbGfMFBbwCpcaDkkbZu7jUoPWT6fbJ3Zh+Ssow=
-github.com/orsinium-forks/wazero v0.0.0-20240305131633-28fdf656fe85/go.mod h1:0U0G41+ochRKoPKCJlh0jMg1CHkyfK8kDqiirMmKY8A=
 github.com/orsinium-labs/tinytest v1.0.0 h1:YiGm/whlGm3mn/ynx9CCFuvEa3Q6yEGrzrKXEqJOkdc=
 github.com/orsinium-labs/tinytest v1.0.0/go.mod h1:GwcYBp0aKi6zujzBXFpCnqw6RSLSp9JSedDyu/V1DF4=
 github.com/orsinium-labs/wypes v0.1.4 h1:+7oih2IDlEpz7laiL3sQFlIU8vjd5j/SwcYlPdIPc0Q=
 github.com/orsinium-labs/wypes v0.1.4/go.mod h1:FSNWGo8I6/D5RYXMkCxyu71TXJAlwJGQUxgs4i6MAwo=
+github.com/tetratelabs/wazero v1.7.1-0.20240401054209-4d6585d7da56 h1:sB7EW6YA2z8k4or+w8Tm2eo1wD/f4uQ31AffFfgRhvo=
+github.com/tetratelabs/wazero v1.7.1-0.20240401054209-4d6585d7da56/go.mod h1:ytl6Zuh20R/eROuyDaGPkp82O9C/DJfXAwJfQ3X6/7Y=
 tinygo.org/x/drivers v0.27.0 h1:TEGk1lQvEhXxfvpEhUu+pwmCnhtldPI+hpHlO9VYixI=
 tinygo.org/x/drivers v0.27.0/go.mod h1:q/mU8G/wz821p8xXqbkBACOlmZFDHXd//DnYnCW+dDQ=
 tinygo.org/x/tinyfont v0.4.0 h1:XexPKEKiHInf6p4CMCJwsIheVPY0T46HUs6ictYyZfE=

--- a/wasmbadge/go.mod
+++ b/wasmbadge/go.mod
@@ -2,8 +2,6 @@ module github.com/hybridgroup/mechanoid-examples/wasmbadge
 
 go 1.22.0
 
-replace github.com/tetratelabs/wazero => github.com/orsinium-forks/wazero v0.0.0-20240305131633-28fdf656fe85
-
 require (
 	github.com/aykevl/board v0.0.0-20240106144210-80ca76f77def
 	github.com/aykevl/tinygl v0.0.0-20240131130748-3033a2fd9182
@@ -34,7 +32,7 @@ require (
 	github.com/srwiley/oksvg v0.0.0-20221011165216-be6e8873101c // indirect
 	github.com/srwiley/rasterx v0.0.0-20220730225603-2ab79fcdd4ef // indirect
 	github.com/stretchr/testify v1.8.4 // indirect
-	github.com/tetratelabs/wazero v1.6.0 // indirect
+	github.com/tetratelabs/wazero v1.7.1-0.20240401054209-4d6585d7da56 // indirect
 	github.com/tevino/abool v1.2.0 // indirect
 	github.com/yuin/goldmark v1.5.5 // indirect
 	golang.org/x/image v0.11.0 // indirect

--- a/wasmbadge/go.sum
+++ b/wasmbadge/go.sum
@@ -235,8 +235,6 @@ github.com/modern-go/reflect2 v0.0.0-20180701023420-4b7aa43c6742/go.mod h1:bx2lN
 github.com/modern-go/reflect2 v1.0.1/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3RllmbCylyMrvgv0=
 github.com/neelance/astrewrite v0.0.0-20160511093645-99348263ae86/go.mod h1:kHJEU3ofeGjhHklVoIGuVj85JJwZ6kWPaJwCIxgnFmo=
 github.com/neelance/sourcemap v0.0.0-20200213170602-2833bce08e4c/go.mod h1:Qr6/a/Q4r9LP1IltGz7tA7iOK1WonHEYhu1HRBA7ZiM=
-github.com/orsinium-forks/wazero v0.0.0-20240305131633-28fdf656fe85 h1:SEURwzbGfMFBbwCpcaDkkbZu7jUoPWT6fbJ3Zh+Ssow=
-github.com/orsinium-forks/wazero v0.0.0-20240305131633-28fdf656fe85/go.mod h1:0U0G41+ochRKoPKCJlh0jMg1CHkyfK8kDqiirMmKY8A=
 github.com/orsinium-labs/tinytest v1.0.0 h1:YiGm/whlGm3mn/ynx9CCFuvEa3Q6yEGrzrKXEqJOkdc=
 github.com/orsinium-labs/tinytest v1.0.0/go.mod h1:GwcYBp0aKi6zujzBXFpCnqw6RSLSp9JSedDyu/V1DF4=
 github.com/orsinium-labs/wypes v0.1.4 h1:+7oih2IDlEpz7laiL3sQFlIU8vjd5j/SwcYlPdIPc0Q=
@@ -283,6 +281,8 @@ github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO
 github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcUk=
 github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
 github.com/subosito/gotenv v1.2.0/go.mod h1:N0PQaV/YGNqwC0u51sEeR/aUtSLEXKX9iv69rRypqCw=
+github.com/tetratelabs/wazero v1.7.1-0.20240401054209-4d6585d7da56 h1:sB7EW6YA2z8k4or+w8Tm2eo1wD/f4uQ31AffFfgRhvo=
+github.com/tetratelabs/wazero v1.7.1-0.20240401054209-4d6585d7da56/go.mod h1:ytl6Zuh20R/eROuyDaGPkp82O9C/DJfXAwJfQ3X6/7Y=
 github.com/tevino/abool v1.2.0 h1:heAkClL8H6w+mK5md9dzsuohKeXHUpY7Vw0ZCKW+huA=
 github.com/tevino/abool v1.2.0/go.mod h1:qc66Pna1RiIsPa7O4Egxxs9OqkuxDX55zznh9K07Tzg=
 github.com/yuin/goldmark v1.1.25/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=

--- a/wasmdrone/go.mod
+++ b/wasmdrone/go.mod
@@ -6,7 +6,6 @@ require (
 	github.com/aykevl/board v0.0.0-20240106144210-80ca76f77def
 	github.com/aykevl/tinygl v0.0.0-20240131130748-3033a2fd9182
 	github.com/hybridgroup/mechanoid v0.0.0-20240309111213-758ddcc58e7a
-	github.com/hybridgroup/mechanoid-examples/buttons v0.0.0-20240310125129-64e802231425
 	github.com/hybridgroup/tinygo-tello v0.0.0-20240310133819-eb8919c64e88
 	github.com/orsinium-labs/wypes v0.1.4
 	tinygo.org/x/drivers v0.27.0
@@ -34,7 +33,7 @@ require (
 	github.com/srwiley/oksvg v0.0.0-20220731023508-a61f04f16b76 // indirect
 	github.com/srwiley/rasterx v0.0.0-20210519020934-456a8d69b780 // indirect
 	github.com/stretchr/testify v1.8.0 // indirect
-	github.com/tetratelabs/wazero v1.6.0 // indirect
+	github.com/tetratelabs/wazero v1.7.1-0.20240401054209-4d6585d7da56 // indirect
 	github.com/tevino/abool v1.2.0 // indirect
 	github.com/yuin/goldmark v1.4.13 // indirect
 	golang.org/x/image v0.3.0 // indirect
@@ -45,5 +44,3 @@ require (
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 	honnef.co/go/js/dom v0.0.0-20210725211120-f030747120f2 // indirect
 )
-
-replace github.com/tetratelabs/wazero => github.com/orsinium-forks/wazero v0.0.0-20240305131633-28fdf656fe85

--- a/wasmdrone/go.sum
+++ b/wasmdrone/go.sum
@@ -202,8 +202,6 @@ github.com/hashicorp/memberlist v0.1.3/go.mod h1:ajVTdAv/9Im8oMAAj5G31PhhMCZJV2p
 github.com/hashicorp/serf v0.8.2/go.mod h1:6hOLApaqBFA1NXqRQAsxw9QxuDEvNxSQRwA/JwenrHc=
 github.com/hybridgroup/mechanoid v0.0.0-20240309111213-758ddcc58e7a h1:7Hdaw1lCpdA85YlgwKk4L974C5k/gxQeEo3LSYsJWT0=
 github.com/hybridgroup/mechanoid v0.0.0-20240309111213-758ddcc58e7a/go.mod h1:goPLq6Qim+Hr7nGeDflbxPNqhErDAdhpUmFp44URbo8=
-github.com/hybridgroup/mechanoid-examples/buttons v0.0.0-20240310125129-64e802231425 h1:hNvw2iNBp5QU7CQgYIB6LoleeXOjKX+fXTpLv4530bQ=
-github.com/hybridgroup/mechanoid-examples/buttons v0.0.0-20240310125129-64e802231425/go.mod h1:KDcH3YkZZ8qjvKfLEzbcrC6Xd8RJ38ky/AcL+L0kfGs=
 github.com/hybridgroup/tinygo-tello v0.0.0-20240310133819-eb8919c64e88 h1:5TR/Z8dNr6jBNRraiegPtQrepSZpwcRx5LMrq9M4StE=
 github.com/hybridgroup/tinygo-tello v0.0.0-20240310133819-eb8919c64e88/go.mod h1:ypUglFzu5zhOgWBFzMQHE7D8L/+6ULhWDXG1PjWkXKE=
 github.com/hybridgroup/wasman v0.0.0-20240304140329-ce1ea6b61834 h1:pP916/7OLromi+7fHcbw5jIXOT/idiEBQ3ucbl8caz8=
@@ -248,8 +246,6 @@ github.com/neelance/sourcemap v0.0.0-20200213170602-2833bce08e4c/go.mod h1:Qr6/a
 github.com/nfnt/resize v0.0.0-20180221191011-83c6a9932646/go.mod h1:jpp1/29i3P1S/RLdc7JQKbRpFeM1dOBd8T9ki5s+AY8=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e h1:fD57ERR4JtEqsWbfPhv4DMiApHyliiK5xCTNVSPiaAs=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
-github.com/orsinium-forks/wazero v0.0.0-20240305131633-28fdf656fe85 h1:SEURwzbGfMFBbwCpcaDkkbZu7jUoPWT6fbJ3Zh+Ssow=
-github.com/orsinium-forks/wazero v0.0.0-20240305131633-28fdf656fe85/go.mod h1:0U0G41+ochRKoPKCJlh0jMg1CHkyfK8kDqiirMmKY8A=
 github.com/orsinium-labs/tinytest v1.0.0 h1:YiGm/whlGm3mn/ynx9CCFuvEa3Q6yEGrzrKXEqJOkdc=
 github.com/orsinium-labs/tinytest v1.0.0/go.mod h1:GwcYBp0aKi6zujzBXFpCnqw6RSLSp9JSedDyu/V1DF4=
 github.com/orsinium-labs/wypes v0.1.4 h1:+7oih2IDlEpz7laiL3sQFlIU8vjd5j/SwcYlPdIPc0Q=
@@ -297,6 +293,8 @@ github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
 github.com/stretchr/testify v1.8.0 h1:pSgiaMZlXftHpm5L7V1+rVB+AZJydKsMxsQBIJw4PKk=
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
 github.com/subosito/gotenv v1.2.0/go.mod h1:N0PQaV/YGNqwC0u51sEeR/aUtSLEXKX9iv69rRypqCw=
+github.com/tetratelabs/wazero v1.7.1-0.20240401054209-4d6585d7da56 h1:sB7EW6YA2z8k4or+w8Tm2eo1wD/f4uQ31AffFfgRhvo=
+github.com/tetratelabs/wazero v1.7.1-0.20240401054209-4d6585d7da56/go.mod h1:ytl6Zuh20R/eROuyDaGPkp82O9C/DJfXAwJfQ3X6/7Y=
 github.com/tevino/abool v1.2.0 h1:heAkClL8H6w+mK5md9dzsuohKeXHUpY7Vw0ZCKW+huA=
 github.com/tevino/abool v1.2.0/go.mod h1:qc66Pna1RiIsPa7O4Egxxs9OqkuxDX55zznh9K07Tzg=
 github.com/urfave/cli/v2 v2.4.0/go.mod h1:NX9W0zmTvedE5oDoOMs2RTC8RvdK98NTYZE5LbaEYPg=

--- a/wasmdrone/modules/drone/go.mod
+++ b/wasmdrone/modules/drone/go.mod
@@ -3,5 +3,3 @@ module github.com/hybridgroup/mechanoid-examples/wasmdrone/modules/drone
 go 1.22.0
 
 require github.com/hybridgroup/mechanoid v0.0.0-20240310110742-7303f6e2a7b5
-
-replace github.com/tetratelabs/wazero => github.com/orsinium-forks/wazero v0.0.0-20240305131633-28fdf656fe85


### PR DESCRIPTION
This PR updates the examples to use the main wazero instead of the fork we were previously needing. Yes!